### PR TITLE
Add right-click context menu functionality

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,15 +1,66 @@
 // background.js (MV3 service-worker)
-chrome.action.onClicked.addListener(async (tab) => {
-  console.log('[MarkdownClipper] toolbar icon clicked, tab:', tab.id);
+
+// Create context menu items
+chrome.runtime.onInstalled.addListener(() => {
+  // Menu item for entire page
+  chrome.contextMenus.create({
+    id: "clip-page",
+    title: "Convert entire page to Markdown",
+    contexts: ["page"]
+  });
+
+  // Menu item for selected text
+  chrome.contextMenus.create({
+    id: "clip-selection",
+    title: "Convert selection to Markdown",
+    contexts: ["selection"]
+  });
+});
+
+// Function to inject clipper scripts
+async function injectClipper(tab, selectionMode = false) {
+  console.log(`[MarkdownClipper] clipper called for tab: ${tab.id}, selection mode: ${selectionMode}`);
   try {
     await chrome.scripting.executeScript({
       target: { tabId: tab.id },
       files: ['content/libs/readability.js',
-              'content/libs/turndown.js',
-              'content/clipper.js']
+              'content/libs/turndown.js']
     });
+
+    if (selectionMode) {
+      // For selection mode, we use custom parameters
+      await chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        func: () => {
+          // Force selection mode in the clipper script
+          window.__mdclipperUseSelection = true;
+        }
+      });
+    }
+
+    // Execute the main clipper script
+    await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      files: ['content/clipper.js']
+    });
+
     console.log('[MarkdownClipper] clipper.js injected OK');
   } catch (e) {
     console.error('Markdown Clipper injection failed:', e);
   }
+}
+
+// Handle context menu clicks
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+  if (info.menuItemId === "clip-page") {
+    injectClipper(tab, false);
+  } else if (info.menuItemId === "clip-selection") {
+    injectClipper(tab, true);
+  }
+});
+
+// Handle toolbar icon click (original functionality)
+chrome.action.onClicked.addListener(async (tab) => {
+  console.log('[MarkdownClipper] toolbar icon clicked, tab:', tab.id);
+  injectClipper(tab);
 });

--- a/content/clipper.js
+++ b/content/clipper.js
@@ -29,8 +29,12 @@
   if ((!html || html.length < 30) && !forceSelection) {
     log('Запускаем Readability');
     const article = new Readability(document.cloneNode(true)).parse();
-    const titleHtml = `<h1>${article.title}</h1>`;
-    html = titleHtml + article ? article.content : '';
+    if (article) {
+      // добавляем <h1> title </h1> перед контентом
+      html = `<h1>${article.title}</h1>` + article.content;
+    } else {
+      html = '';
+    }
   }
 
   if (!html) {

--- a/content/clipper.js
+++ b/content/clipper.js
@@ -29,7 +29,8 @@
   if ((!html || html.length < 30) && !forceSelection) {
     log('Запускаем Readability');
     const article = new Readability(document.cloneNode(true)).parse();
-    html = article ? article.content : '';
+    const titleHtml = `<h1>${article.title}</h1>`;
+    html = titleHtml + article ? article.content : '';
   }
 
   if (!html) {

--- a/content/clipper.js
+++ b/content/clipper.js
@@ -14,6 +14,9 @@
   ----------------------------------------------*/
   const sel = getSelection();
   let html = null;
+  const forceSelection = window.__mdclipperUseSelection === true;
+
+  // Check for selection
   if (sel && !sel.isCollapsed) {
     const range = sel.getRangeAt(0).cloneContents();
     const div = document.createElement('div');
@@ -21,11 +24,14 @@
     html = div.innerHTML.trim();
     log('Используем выделенный фрагмент');
   }
-  if (!html || html.length < 30) {
+
+  // If no selection or selection is too small and we're not in selection-only mode
+  if ((!html || html.length < 30) && !forceSelection) {
     log('Запускаем Readability');
     const article = new Readability(document.cloneNode(true)).parse();
     html = article ? article.content : '';
   }
+
   if (!html) {
     alert('Markdown Page Clipper: не удалось извлечь содержимое.');
     return;

--- a/content/clipper.js
+++ b/content/clipper.js
@@ -17,7 +17,7 @@
   const forceSelection = window.__mdclipperUseSelection === true;
 
   // Check for selection
-  if (sel && !sel.isCollapsed && sel.toString().trim().length >= 30) {
+  if (sel && !sel.isCollapsed) {
     const range = sel.getRangeAt(0).cloneContents();
     const div = document.createElement('div');
     div.appendChild(range);
@@ -29,19 +29,7 @@
   if ((!html || html.length < 30) && !forceSelection) {
     log('Запускаем Readability');
     const article = new Readability(document.cloneNode(true)).parse();
-    if (!article) { alert('Не удалось извлечь содержимое'); return; }
-    let title = article.title?.trim() || '';
-    
-    if (!title) {
-      // fallback: ищем первый <h1> в content
-      const tmp = document.createElement('div');
-      tmp.innerHTML = article.content;
-      const h1  = tmp.querySelector('h1');
-      title = h1 ? h1.textContent.trim() : '';
-    }
-    html = (title ? `<h1>${title}</h1>` : '') + article.content;
-    log('Readability ok, title =', title);
-    }
+    html = article ? article.content : '';
   }
 
   if (!html) {

--- a/content/clipper.js
+++ b/content/clipper.js
@@ -17,7 +17,7 @@
   const forceSelection = window.__mdclipperUseSelection === true;
 
   // Check for selection
-  if (sel && !sel.isCollapsed) {
+  if (sel && !sel.isCollapsed && sel.toString().trim().length >= 30) {
     const range = sel.getRangeAt(0).cloneContents();
     const div = document.createElement('div');
     div.appendChild(range);
@@ -29,11 +29,18 @@
   if ((!html || html.length < 30) && !forceSelection) {
     log('Запускаем Readability');
     const article = new Readability(document.cloneNode(true)).parse();
-    if (article) {
-      // добавляем <h1> title </h1> перед контентом
-      html = `<h1>${article.title}</h1>` + article.content;
-    } else {
-      html = '';
+    if (!article) { alert('Не удалось извлечь содержимое'); return; }
+    let title = article.title?.trim() || '';
+    
+    if (!title) {
+      // fallback: ищем первый <h1> в content
+      const tmp = document.createElement('div');
+      tmp.innerHTML = article.content;
+      const h1  = tmp.querySelector('h1');
+      title = h1 ? h1.textContent.trim() : '';
+    }
+    html = (title ? `<h1>${title}</h1>` : '') + article.content;
+    log('Readability ok, title =', title);
     }
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,8 @@
     "activeTab",
     "scripting",
     "clipboardWrite",
-    "clipboardRead"
+    "clipboardRead",
+    "contextMenus"
   ],
 
   "background": {


### PR DESCRIPTION
## Summary
- Added right-click context menu functionality with two options:
  - Convert entire page to Markdown (appears on page right-click)
  - Convert selection to Markdown (appears when text is selected)
- Added contextMenus permission in the manifest
- Modified background.js to handle context menu events
- Updated clipper.js to respect selection mode